### PR TITLE
[Fix] plist에서 APP_GROUP_NAME 불러올 때 인식 불가 문제 해결 #20

### DIFF
--- a/ScreenTimeReport/ScreenTimeActivityReport.swift
+++ b/ScreenTimeReport/ScreenTimeActivityReport.swift
@@ -1,0 +1,31 @@
+//
+//  ScreenTimeActivityReport.swift
+//  ScreenTimeReport
+//
+//  Created by 김영빈 on 2023/08/11.
+//
+
+// MARK: - Device Activity Report 관련 데이터 모델이 정의되어 있는 파일입니다.
+import Foundation
+
+struct ActivityReport {
+    let totalDuration: TimeInterval
+    let apps: [AppDeviceActivity]
+}
+
+struct AppDeviceActivity: Identifiable {
+    var id: String
+    var displayName: String
+    var duration: TimeInterval
+    var numberOfPickups: Int
+}
+
+extension TimeInterval {
+    /// TimeInterval 타입 값을 00:00 형식의 String으로 변환해주는 메서드
+    func toString() -> String {
+        let time = NSInteger(self)
+        let minutes = (time / 60) % 60
+        let hours = (time / 3600)
+        return String(format: "%0.2d:%0.2d", hours,minutes)
+    }
+}

--- a/ScreenTimeReport/ScreenTimeReport.swift
+++ b/ScreenTimeReport/ScreenTimeReport.swift
@@ -13,7 +13,7 @@ struct ScreenTimeReport: DeviceActivityReportExtension {
     var body: some DeviceActivityReportScene {
         // Create a report for each DeviceActivityReport.Context that your app supports.
         TotalActivityReport { totalActivity in
-            TotalActivityView(totalActivity: totalActivity)
+            TotalActivityView(activityReport: totalActivity)
         }
         // Add more reports here...
     }

--- a/ScreenTimeReport/TotalActivityReport.swift
+++ b/ScreenTimeReport/TotalActivityReport.swift
@@ -38,6 +38,7 @@ struct TotalActivityReport: DeviceActivityReportScene {
             $0 + $1.totalActivityDuration
         })
         
+        /// DeviceActivityResults 데이터에서 화면에 보여주기 위해 필요한 내용을 추출해줍니다.
         for await d in data {
             totalScreenTime += d.user.appleID!.debugDescription
             totalScreenTime += d.lastUpdatedDate.description

--- a/ScreenTimeReport/TotalActivityReport.swift
+++ b/ScreenTimeReport/TotalActivityReport.swift
@@ -39,10 +39,10 @@ struct TotalActivityReport: DeviceActivityReportScene {
         })
         
         /// DeviceActivityResults 데이터에서 화면에 보여주기 위해 필요한 내용을 추출해줍니다.
-        for await d in data {
-            totalScreenTime += d.user.appleID!.debugDescription
-            totalScreenTime += d.lastUpdatedDate.description
-            for await activitySegment in d.activitySegments {
+        for await eachData in data {
+            totalScreenTime += eachData.user.appleID!.debugDescription
+            totalScreenTime += eachData.lastUpdatedDate.description
+            for await activitySegment in eachData.activitySegments {
                 totalScreenTime += activitySegment.totalActivityDuration.formatted()
                 for await category in activitySegment.categories {
                     for await application in category.applications {
@@ -50,12 +50,12 @@ struct TotalActivityReport: DeviceActivityReportScene {
                         let bundle = (application.application.bundleIdentifier ?? "nil")
                         let duration = application.totalActivityDuration
                         let numberOfPickups = application.numberOfPickups
-                        let app = AppDeviceActivity(
+                        let appActivity = AppDeviceActivity(
                             id: bundle,
                             displayName: appName,
                             duration: duration,
                             numberOfPickups: numberOfPickups)
-                        list.append(app)
+                        list.append(appActivity)
                     }
                 }
                 

--- a/ScreenTimeReport/TotalActivityReport.swift
+++ b/ScreenTimeReport/TotalActivityReport.swift
@@ -8,20 +8,26 @@
 import DeviceActivity
 import SwiftUI
 
+// MARK: - 각각의 Device Activity Report들에 대응하는 컨텍스트 정의
 extension DeviceActivityReport.Context {
     // If your app initializes a DeviceActivityReport with this context, then the system will use
     // your extension's corresponding DeviceActivityReportScene to render the contents of the
     // report.
+    /// 해당 리포트의 내용 렌더링에 사용할 DeviceActivityReportScene에 대응하는 익스텐션이 필요합니다.  ex) TotalActivityReport
     static let totalActivity = Self("Total Activity")
 }
 
+// MARK: - Device Activity Report의 내용을 어떻게 구성할 지 설정
 struct TotalActivityReport: DeviceActivityReportScene {
     // Define which context your scene will represent.
+    /// 보여줄 리포트에 대한 컨텍스트를 정의해줍니다.
     let context: DeviceActivityReport.Context = .totalActivity
     
     // Define the custom configuration and the resulting view for this report.
+    /// 어떤 데이터를 사용해서 어떤 뷰를 보여줄 지 정의해줍니다. (SwiftUI View)
     let content: (String) -> TotalActivityView
     
+    /// DeviceActivityResults 데이터를 받아서 필터링
     func makeConfiguration(representing data: DeviceActivityResults<DeviceActivityData>) async -> String {
         // Reformat the data into a configuration that can be used to create
         // the report's view.

--- a/ScreenTimeReport/TotalActivityView.swift
+++ b/ScreenTimeReport/TotalActivityView.swift
@@ -17,8 +17,20 @@ struct TotalActivityView: View {
             Text("Total Screen Time")
             Spacer(minLength: 10)
             Text(activityReport.totalDuration.toString())
-            List(activityReport.apps) { app in
-                ListRow(eachApp: app)
+            List {
+                HStack {
+                    Text("앱")
+                    Spacer()
+                    Text("앱ID")
+                    Spacer()
+                    Text("클릭 횟수")
+                    Spacer()
+                    Text("모니터링 시간")
+                }
+                
+                ForEach(activityReport.apps) { eachApp in
+                    ListRow(eachApp: eachApp)
+                }
             }
         }
     }
@@ -40,11 +52,19 @@ struct ListRow: View {
     }
 }
 
-//// In order to support previews for your extension's custom views, make sure its source files are
-//// members of your app's Xcode target as well as members of your extension's target. You can use
-//// Xcode's File Inspector to modify a file's Target Membership.
-//struct TotalActivityView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        TotalActivityView(totalActivity: "1h 23m")
-//    }
-//}
+// In order to support previews for your extension's custom views, make sure its source files are
+// members of your app's Xcode target as well as members of your extension's target. You can use
+// Xcode's File Inspector to modify a file's Target Membership.
+struct TotalActivityView_Previews: PreviewProvider {
+    static var previews: some View {
+        TotalActivityView(
+            activityReport: ActivityReport(
+                totalDuration: .zero,
+                apps: [
+                    AppDeviceActivity(id: "id1", displayName: "app1", duration: .zero, numberOfPickups: 3),
+                    AppDeviceActivity(id: "id2", displayName: "app2", duration: .zero, numberOfPickups: 5)
+                ]
+            )
+        )
+    }
+}

--- a/ScreenTimeReport/TotalActivityView.swift
+++ b/ScreenTimeReport/TotalActivityView.swift
@@ -7,19 +7,44 @@
 
 import SwiftUI
 
+// MARK: - MonitoringView에서 보여줄 SwiftUI 뷰
 struct TotalActivityView: View {
-    let totalActivity: String
+    var activityReport: ActivityReport
     
     var body: some View {
-        Text(totalActivity)
+        VStack {
+            Spacer(minLength: 50)
+            Text("Total Screen Time")
+            Spacer(minLength: 10)
+            Text(activityReport.totalDuration.toString())
+            List(activityReport.apps) { app in
+                ListRow(eachApp: app)
+            }
+        }
     }
 }
 
-// In order to support previews for your extension's custom views, make sure its source files are
-// members of your app's Xcode target as well as members of your extension's target. You can use
-// Xcode's File Inspector to modify a file's Target Membership.
-struct TotalActivityView_Previews: PreviewProvider {
-    static var previews: some View {
-        TotalActivityView(totalActivity: "1h 23m")
+struct ListRow: View {
+    var eachApp: AppDeviceActivity
+    
+    var body: some View {
+        HStack {
+            Text(eachApp.displayName)
+            Spacer()
+            Text(eachApp.id)
+            Spacer()
+            Text("\(eachApp.numberOfPickups)")
+            Spacer()
+            Text(String(eachApp.duration.formatted()))
+        }
     }
 }
+
+//// In order to support previews for your extension's custom views, make sure its source files are
+//// members of your app's Xcode target as well as members of your extension's target. You can use
+//// Xcode's File Inspector to modify a file's Target Membership.
+//struct TotalActivityView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TotalActivityView(totalActivity: "1h 23m")
+//    }
+//}

--- a/ScreenTime_Barebones.xcodeproj/project.pbxproj
+++ b/ScreenTime_Barebones.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		A9F327D82A836A310075CD7F /* DeviceActivtyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F327D72A836A310075CD7F /* DeviceActivtyManager.swift */; };
 		A9F327DA2A836CB20075CD7F /* ScheduleVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F327D92A836CB20075CD7F /* ScheduleVM.swift */; };
 		B82064F22A85CD2A00B358A2 /* ScreenTimeActivityReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82064F12A85CD2A00B358A2 /* ScreenTimeActivityReport.swift */; };
+		B82064F32A85D7B400B358A2 /* TotalActivityReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84A0ABC2A83CFE800EA9571 /* TotalActivityReport.swift */; };
+		B82064F42A85DFA800B358A2 /* ScreenTimeActivityReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82064F12A85CD2A00B358A2 /* ScreenTimeActivityReport.swift */; };
+		B82064F52A85DFAB00B358A2 /* TotalActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84A0ABE2A83CFE800EA9571 /* TotalActivityView.swift */; };
 		B84A0ABB2A83CFE800EA9571 /* ScreenTimeReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84A0ABA2A83CFE800EA9571 /* ScreenTimeReport.swift */; };
 		B84A0ABD2A83CFE800EA9571 /* TotalActivityReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84A0ABC2A83CFE800EA9571 /* TotalActivityReport.swift */; };
 		B84A0ABF2A83CFE800EA9571 /* TotalActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84A0ABE2A83CFE800EA9571 /* TotalActivityView.swift */; };
@@ -643,9 +646,12 @@
 				A9F327D22A827FBE0075CD7F /* MainTabVM.swift in Sources */,
 				A9E344212A851AD7002288F8 /* Color+Extension.swift in Sources */,
 				A9F327CD2A81DE140075CD7F /* FamilyControlsManager.swift in Sources */,
+				B82064F52A85DFAB00B358A2 /* TotalActivityView.swift in Sources */,
 				A9F327602A80DFDD0075CD7F /* ScreenTime_BarebonesApp.swift in Sources */,
 				A9F327782A81CE8C0075CD7F /* MonitoringView.swift in Sources */,
+				B82064F32A85D7B400B358A2 /* TotalActivityReport.swift in Sources */,
 				A9F327DA2A836CB20075CD7F /* ScheduleVM.swift in Sources */,
+				B82064F42A85DFA800B358A2 /* ScreenTimeActivityReport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -843,7 +849,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ScreenTime_Barebones/Preview Content\"";
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "ScreenTime-Barebones-Info.plist";
@@ -876,7 +882,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ScreenTime_Barebones/Preview Content\"";
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "ScreenTime-Barebones-Info.plist";
@@ -905,7 +911,7 @@
 				CODE_SIGN_ENTITLEMENTS = DeviceActivityMonitor/DeviceActivityMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DeviceActivityMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = DeviceActivityMonitor;
@@ -931,7 +937,7 @@
 				CODE_SIGN_ENTITLEMENTS = DeviceActivityMonitor/DeviceActivityMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DeviceActivityMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = DeviceActivityMonitor;
@@ -957,7 +963,7 @@
 				CODE_SIGN_ENTITLEMENTS = ShieldAction/ShieldAction.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShieldAction/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldAction;
@@ -983,7 +989,7 @@
 				CODE_SIGN_ENTITLEMENTS = ShieldAction/ShieldAction.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShieldAction/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldAction;
@@ -1009,7 +1015,7 @@
 				CODE_SIGN_ENTITLEMENTS = ShieldConfiguration/ShieldConfiguration.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShieldConfiguration/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldConfiguration;
@@ -1035,7 +1041,7 @@
 				CODE_SIGN_ENTITLEMENTS = ShieldConfiguration/ShieldConfiguration.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShieldConfiguration/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ShieldConfiguration;
@@ -1061,7 +1067,7 @@
 				CODE_SIGN_ENTITLEMENTS = ScreenTimeReport/ScreenTimeReport.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ScreenTimeReport/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ScreenTimeReport;
@@ -1088,7 +1094,7 @@
 				CODE_SIGN_ENTITLEMENTS = ScreenTimeReport/ScreenTimeReport.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = V7Y39HNV38;
+				DEVELOPMENT_TEAM = RCM87YWJ79;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ScreenTimeReport/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ScreenTimeReport;

--- a/ScreenTime_Barebones.xcodeproj/project.pbxproj
+++ b/ScreenTime_Barebones.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		A9F327D42A827FDF0075CD7F /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F327D32A827FDF0075CD7F /* MainTabView.swift */; };
 		A9F327D82A836A310075CD7F /* DeviceActivtyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F327D72A836A310075CD7F /* DeviceActivtyManager.swift */; };
 		A9F327DA2A836CB20075CD7F /* ScheduleVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F327D92A836CB20075CD7F /* ScheduleVM.swift */; };
+		B82064F22A85CD2A00B358A2 /* ScreenTimeActivityReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82064F12A85CD2A00B358A2 /* ScreenTimeActivityReport.swift */; };
 		B84A0ABB2A83CFE800EA9571 /* ScreenTimeReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84A0ABA2A83CFE800EA9571 /* ScreenTimeReport.swift */; };
 		B84A0ABD2A83CFE800EA9571 /* TotalActivityReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84A0ABC2A83CFE800EA9571 /* TotalActivityReport.swift */; };
 		B84A0ABF2A83CFE800EA9571 /* TotalActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84A0ABE2A83CFE800EA9571 /* TotalActivityView.swift */; };
@@ -150,6 +151,7 @@
 		A9F327D32A827FDF0075CD7F /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		A9F327D72A836A310075CD7F /* DeviceActivtyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceActivtyManager.swift; sourceTree = "<group>"; };
 		A9F327D92A836CB20075CD7F /* ScheduleVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleVM.swift; sourceTree = "<group>"; };
+		B82064F12A85CD2A00B358A2 /* ScreenTimeActivityReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeActivityReport.swift; sourceTree = "<group>"; };
 		B84A0AB82A83CFE800EA9571 /* ScreenTimeReport.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = ScreenTimeReport.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B84A0ABA2A83CFE800EA9571 /* ScreenTimeReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeReport.swift; sourceTree = "<group>"; };
 		B84A0ABC2A83CFE800EA9571 /* TotalActivityReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalActivityReport.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				B84A0ABE2A83CFE800EA9571 /* TotalActivityView.swift */,
 				B84A0AC02A83CFE800EA9571 /* Info.plist */,
 				B84A0AC12A83CFE800EA9571 /* ScreenTimeReport.entitlements */,
+				B82064F12A85CD2A00B358A2 /* ScreenTimeActivityReport.swift */,
 			);
 			path = ScreenTimeReport;
 			sourceTree = "<group>";
@@ -681,6 +684,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B84A0ABF2A83CFE800EA9571 /* TotalActivityView.swift in Sources */,
+				B82064F22A85CD2A00B358A2 /* ScreenTimeActivityReport.swift in Sources */,
 				B84A0ABB2A83CFE800EA9571 /* ScreenTimeReport.swift in Sources */,
 				B84A0ABD2A83CFE800EA9571 /* TotalActivityReport.swift in Sources */,
 				A9E344322A85D67B002288F8 /* Bundle+Extension.swift in Sources */,

--- a/ScreenTime_Barebones/App/XCConfig/shared.xcconfig
+++ b/ScreenTime_Barebones/App/XCConfig/shared.xcconfig
@@ -9,4 +9,5 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 // App Group
-APP_GROUP_NAME = "group.coffeenaerirei.screen_time_barebones"
+/// ‼️ 값에 따옴표를 넣으면 따옴표도 같이 문자열에 포함됩니다.
+APP_GROUP_NAME = group.coffeenaerirei.screen_time_barebones

--- a/ScreenTime_Barebones/Extension/Bundle+Extension.swift
+++ b/ScreenTime_Barebones/Extension/Bundle+Extension.swift
@@ -8,28 +8,37 @@
 import Foundation
 
 extension Bundle {
-    var appGroupName: String {
-        guard let filePath = Bundle.main.path(forResource: "ScreenTime-Barebones-Info", ofType: "plist"),
-              let plistDict = NSDictionary(contentsOfFile: filePath)
-        else {
-            fatalError("Couldn't find file 'ScreenTime-Barebones-Info.plist'.")
-        }
-
-        // plist 안쪽에 사용할 Key값을 입력해주세요.
-        guard let value = plistDict.object(forKey: "APP_GROUP_NAME") as? String else {
-            fatalError("Couldn't find key 'APP_GROUP_NAME' in 'ScreenTime-Barebones-Info.plist'.")
-        }
-
-        return value
-    }
+    // TODO: - 확인 후 주석 삭제
+//    var appGroupName: String {
+//        guard let filePath = Bundle.main.path(forResource: "ScreenTime-Barebones-Info", ofType: "plist"),
+//              let plistDict = NSDictionary(contentsOfFile: filePath)
+//        else {
+//            fatalError("Couldn't find file 'ScreenTime-Barebones-Info.plist'.")
+//        }
+//
+//        // plist 안쪽에 사용할 Key값을 입력해주세요.
+//        guard let value = plistDict.object(forKey: "APP_GROUP_NAME") as? String else {
+//            fatalError("Couldn't find key 'APP_GROUP_NAME' in 'ScreenTime-Barebones-Info.plist'.")
+//        }
+//
+//        return value
+//    }
+//
+//    static let APP_GROUP_NAME: String = {
+//        guard let value = Bundle.main.infoDictionary?["APP_GROUP_NAME"] as? String else {
+//            fatalError("APP_NAME not set in Info.plist")
+//        }
+//
+//        print(value)
+//
+//        return value
+//    }()
     
-    static let APP_GROUP_NAME: String = {
+    var APP_GROUP_NAME: String {
+        /// plist 파일에서 key값에 해당하는 값을 String으로 불러옵니다.
         guard let value = Bundle.main.infoDictionary?["APP_GROUP_NAME"] as? String else {
             fatalError("APP_NAME not set in Info.plist")
         }
-        
-        print(value)
-        
         return value
-    }()
+    }
 }

--- a/ScreenTime_Barebones/Presentation/ViewModels/ScheduleVM.swift
+++ b/ScreenTime_Barebones/Presentation/ViewModels/ScheduleVM.swift
@@ -43,14 +43,13 @@ enum ScheduleSectionInfo {
 }
 
 // MARK: - TODO 미친 이슈 발생. String으로 값을 직접 넘겨주지 않을 때 userDefault가 정상동작하지 않음.
-
+// TODO: - 너굴맨이 해치웠으니 안심하고 주석 삭제
+// let APP_GROUP_NAME = "group.coffeenaerirei.screen_time_barebones"
+//let APP_GROUP_NAME = Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_NAME") as! String
+// let APP_GROUP_NAME = Bundle.main.appGroupName
 // let APP_GROUP_NAME = "group.coffeenaerirei.screen_time_barebones"
 
-// let APP_GROUP_NAME = Bundle.main.object(forInfoDictionaryKey: "APP_GROUP_NAME") as! String
-
-// let APP_GROUP_NAME = Bundle.main.appGroupName
-
-let APP_GROUP_NAME = "group.coffeenaerirei.screen_time_barebones"
+let APP_GROUP_NAME = Bundle.main.APP_GROUP_NAME
 
 class ScheduleVM: ObservableObject {
     // MARK: - 스케쥴 설정을 위한 멤버 변수

--- a/ScreenTime_Barebones/Presentation/Views/MonitoringView/MonitoringView.swift
+++ b/ScreenTime_Barebones/Presentation/Views/MonitoringView/MonitoringView.swift
@@ -5,16 +5,35 @@
 //  Created by Yun Dongbeom on 2023/08/08.
 //
 
+import DeviceActivity
 import SwiftUI
 
 struct MonitoringView: View {
+    @ObservedObject var vm = ScheduleVM()
+    
+    @State private var context: DeviceActivityReport.Context = .totalActivity
+    @State private var filter = DeviceActivityFilter(segment: .daily(during: Calendar.current.dateInterval(of: .day, for: .now)!))
+    
     var body: some View {
-        Text("I'm Monitoring")
+        DeviceActivityReport(context, filter: filter)
+            .onAppear {
+                filter = DeviceActivityFilter(
+                    segment: .daily(
+                        during: Calendar.current.dateInterval(
+                            of: .day, for: .now
+                        )!
+                    ),
+                    users: .all,
+                    devices: .init([.iPhone]),
+                    applications: vm.selection.applicationTokens,
+                    categories: vm.selection.categoryTokens
+                )
+            }
     }
 }
 
-struct MonitoringView_Previews: PreviewProvider {
-    static var previews: some View {
-        MonitoringView()
-    }
-}
+//struct MonitoringView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        MonitoringView()
+//    }
+//}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [X] 추가/변경사항에 대한 테스트는 진행했나요?
- [X] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Feat: 새로운 기능을 추가
- [X] Fix: 버그 수정
- [ ] Design: CSS 등 사용자 UI 디자인 변경
- [ ] !BREAKING CHANGE: 커다란 API 변경의 경우
- [ ] !HOTFIX: 급하게 치명적인 버그를 고쳐야하는 경우
- [ ] Style: 코드 포맷 변경, 세미 콜론 누락, 코드 수정이 없는 경우
- [ ] Refactor: 프로덕션 코드 리팩토링
- [ ] Comment: 필요한 주석 추가 및 변경
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 코드, 리펙토링 테스트 코드 추가, Production Code(실제로 사용하는 코드) 변경 없음
- [ ] Chore: 빌드 업무 수정, 패키지 매니저 수정, 패키지 관리자 구성 등 업데이트, Production Code 변경 없음
- [ ] Rename: 파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
- [ ] Remove: 파일을 삭제하는 작업만 수행한 경우

## What is the current behavior?

#20 이슈에 해당하는 문제를 해결했습니다.

추가/변경사항에 대해 작성해주세요.
- 스크린샷 보시면 plist에서 불러오는 값들에는 따옴표가 붙어 있습니다.
<img width="822" alt="스크린샷 2023-08-14 오전 12 09 45" src="https://github.com/CoffeeNaeriRei/ScreenTime_Barebones/assets/89764127/ae42a311-cf49-47be-a97d-b59448b00442">

- shared.xconfig 에서 값을 불러올 땐 붙어 있는 따옴표도 문자열에 포함되는 것 같아 APP_GROUP_NAME 값에 붙은 따옴표를 제거해줬습니다.
<img width="534" alt="스크린샷 2023-08-14 오전 12 10 24" src="https://github.com/CoffeeNaeriRei/ScreenTime_Barebones/assets/89764127/9c2b193f-baa8-47a8-a4fa-ea441794aef0">

- Bundle+Extension 에서 APP_GROUP_NAME 값을 불러오는 부분도 조금 수정했습니다.
<img width="592" alt="image" src="https://github.com/CoffeeNaeriRei/ScreenTime_Barebones/assets/89764127/b4bbb34c-5896-492f-bbff-b54e91e1e563">

- 아래 사진처럼 불러와서 사용해주면 됩니다. (ScheduleVM.swift)
<img width="445" alt="image" src="https://github.com/CoffeeNaeriRei/ScreenTime_Barebones/assets/89764127/8749d50f-6af0-4d82-8bab-9a03c789a51e">



Issue Number: #20

## Other information