### PR TITLE
[Feat] MonitoringView 개선 작업

### DIFF
--- a/ScreenTimeReport/ScreenTimeActivityReport.swift
+++ b/ScreenTimeReport/ScreenTimeActivityReport.swift
@@ -17,7 +17,7 @@ struct ActivityReport {
 struct AppDeviceActivity: Identifiable {
     var id: String
     var displayName: String
-    var labelToken: ActivityCategoryToken
+    var labelToken: ApplicationToken
     var duration: TimeInterval
     var numberOfPickups: Int
     var token: ApplicationToken?

--- a/ScreenTimeReport/ScreenTimeActivityReport.swift
+++ b/ScreenTimeReport/ScreenTimeActivityReport.swift
@@ -17,7 +17,6 @@ struct ActivityReport {
 struct AppDeviceActivity: Identifiable {
     var id: String
     var displayName: String
-    var labelToken: ApplicationToken
     var duration: TimeInterval
     var numberOfPickups: Int
     var token: ApplicationToken?

--- a/ScreenTimeReport/ScreenTimeActivityReport.swift
+++ b/ScreenTimeReport/ScreenTimeActivityReport.swift
@@ -17,6 +17,7 @@ struct ActivityReport {
 struct AppDeviceActivity: Identifiable {
     var id: String
     var displayName: String
+    var labelToken: ActivityCategoryToken
     var duration: TimeInterval
     var numberOfPickups: Int
     var token: ApplicationToken?

--- a/ScreenTimeReport/TotalActivityReport.swift
+++ b/ScreenTimeReport/TotalActivityReport.swift
@@ -56,7 +56,6 @@ struct TotalActivityReport: DeviceActivityReportScene {
                         let appActivity = AppDeviceActivity(
                             id: bundle,
                             displayName: appName,
-                            labelToken: appToken,
                             duration: duration,
                             numberOfPickups: numberOfPickups,
                             token: token

--- a/ScreenTimeReport/TotalActivityReport.swift
+++ b/ScreenTimeReport/TotalActivityReport.swift
@@ -56,6 +56,7 @@ struct TotalActivityReport: DeviceActivityReportScene {
                         let appActivity = AppDeviceActivity(
                             id: bundle,
                             displayName: appName,
+                            labelToken: appToken,
                             duration: duration,
                             numberOfPickups: numberOfPickups,
                             token: token

--- a/ScreenTimeReport/TotalActivityView.swift
+++ b/ScreenTimeReport/TotalActivityView.swift
@@ -81,19 +81,19 @@ struct ListRow: View {
     }
 }
 
-// In order to support previews for your extension's custom views, make sure its source files are
-// members of your app's Xcode target as well as members of your extension's target. You can use
-// Xcode's File Inspector to modify a file's Target Membership.
-struct TotalActivityView_Previews: PreviewProvider {
-    static var previews: some View {
-        TotalActivityView(
-            activityReport: ActivityReport(
-                totalDuration: .zero,
-                apps: [
-                    AppDeviceActivity(id: "id1", displayName: "app1", duration: .zero, numberOfPickups: 3),
-                    AppDeviceActivity(id: "id2", displayName: "app2", duration: .zero, numberOfPickups: 5)
-                ]
-            )
-        )
-    }
-}
+//// In order to support previews for your extension's custom views, make sure its source files are
+//// members of your app's Xcode target as well as members of your extension's target. You can use
+//// Xcode's File Inspector to modify a file's Target Membership.
+//struct TotalActivityView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TotalActivityView(
+//            activityReport: ActivityReport(
+//                totalDuration: .zero,
+//                apps: [
+//                    AppDeviceActivity(id: "id1", displayName: "app1", duration: .zero, numberOfPickups: 3),
+//                    AppDeviceActivity(id: "id2", displayName: "app2", duration: .zero, numberOfPickups: 5)
+//                ]
+//            )
+//        )
+//    }
+//}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] 팀원들과 약속한 커밋메세지 룰을 지켜서 작성했나요?
- [X] 추가/변경사항에 대한 테스트는 진행했나요?
- [X] 추가/변경사항에 대한 문서는 수정했나요?

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Feat: 새로운 기능을 추가
- [ ] Fix: 버그 수정
- [ ] Design: CSS 등 사용자 UI 디자인 변경
- [ ] !BREAKING CHANGE: 커다란 API 변경의 경우
- [ ] !HOTFIX: 급하게 치명적인 버그를 고쳐야하는 경우
- [ ] Style: 코드 포맷 변경, 세미 콜론 누락, 코드 수정이 없는 경우
- [ ] Refactor: 프로덕션 코드 리팩토링
- [ ] Comment: 필요한 주석 추가 및 변경
- [ ] Docs: 문서 수정
- [ ] Test: 테스트 코드, 리펙토링 테스트 코드 추가, Production Code(실제로 사용하는 코드) 변경 없음
- [ ] Chore: 빌드 업무 수정, 패키지 매니저 수정, 패키지 관리자 구성 등 업데이트, Production Code 변경 없음
- [ ] Rename: 파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우
- [ ] Remove: 파일을 삭제하는 작업만 수행한 경우

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Device Activity Report 화면에서 선택한 앱들에 대한 정보만 나오도록 수정함
  - 스크린타임 총 사용시간 계산 위치를 바꿔서 선택한 앱들에 대해서만 계산되도록 해줌
<img width="724" alt="스크린타임 계산" src="https://github.com/CoffeeNaeriRei/ScreenTime_Barebones/assets/89764127/15576893-d99b-4535-9ee7-a358ca545771">

### 결과 화면
<img width="300" alt="선택" src="https://github.com/CoffeeNaeriRei/ScreenTime_Barebones/assets/89764127/58bfe77c-f44d-49b4-a06a-5f00cb56fd20">
<img width="300" alt="모니터링" src="https://github.com/CoffeeNaeriRei/ScreenTime_Barebones/assets/89764127/180eed21-8f0c-4be5-b5e9-74dbbf88e4c5">



Issue Number: #25

## Other information
- 현재는 familyActivityPicker로 선택하면 바로 Device Activity Report 화면에 반영되는 상태입니다.
👉 [스케쥴 저장] 버튼을 눌러서 제한을 시작했을 때부터 Device Activity Report 화면에 보여지도록 할 지, familyActivityPicker로 선택하면 바로 Device Activity Report 화면에 보여지도록 할 지 정해야 할 것 같습니다.

👉 Pickup이 앱을 클릭한 횟수가 아니라, '깨우기 횟수' 를 의미한다고 합니다. 앱 UI에서 해당 부분에 대한 명칭의 수정이 필요해 보입니다.